### PR TITLE
New client operation to delete workflows

### DIFF
--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -74,18 +74,22 @@ func (c *Client) GetWorkflow(workflowID string) (*Workflow, error) {
 }
 
 // DeleteWorkflow - Deletes a workflow.
-func (c *Client) DeleteWorkflow(workflowID string) error {
+func (c *Client) DeleteWorkflow(workflowID string) (*Workflow, error) {
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/api/v1/workflows/%s", c.HostURL, workflowID), nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	body, err := c.doRequest(req, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// NOTE: the DELETE API returns the workflow payload in the body,
-	//  should we do any extra validation beyond the HTTP StatusCode?
-	return nil
+	workflow := Workflow{}
+	err = json.Unmarshal(body, &workflow)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workflow, nil
 }

--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -72,3 +72,20 @@ func (c *Client) GetWorkflow(workflowID string) (*Workflow, error) {
 
 	return &workflow, nil
 }
+
+// DeleteWorkflow - Deletes a workflow.
+func (c *Client) DeleteWorkflow(workflowID string) error {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/api/v1/workflows/%s", c.HostURL, workflowID), nil)
+	if err != nil {
+		return err
+	}
+
+	body, err := c.doRequest(req, nil)
+	if err != nil {
+		return err
+	}
+
+	// NOTE: the DELETE API returns the workflow payload in the body,
+	//  should we do any extra validation beyond the HTTP StatusCode?
+	return nil
+}

--- a/internal/pkg/n8n-client-go/workflows_test.go
+++ b/internal/pkg/n8n-client-go/workflows_test.go
@@ -6,6 +6,7 @@ package n8n
 import (
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
 )
 
@@ -79,6 +80,54 @@ func TestGetWorkflow(t *testing.T) {
 	workflow, err := client.GetWorkflow("1")
 	if err != nil {
 		t.Fatalf("GetWorkflow returned an error: %v", err)
+	}
+
+	if workflow.ID != "3LODqkaWPmYOi0FA" {
+		t.Errorf("unexpected workflow data: %+v", workflow)
+	}
+}
+
+func TestDeleteWorkflow(t *testing.T) {
+	mockID := "3LODqkaWPmYOi0FA"
+	mockResponse := `{"id": "3LODqkaWPmYOi0FA", "name": "Test Workflow"}`
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE request, got %s", r.Method)
+		}
+		if path.Base(r.URL.Path) != mockID {
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write([]byte(`{}`)); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(mockResponse)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	})
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	token := "test-token"
+	client, err := NewClient(&ts.URL, &token)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	// HTTP 404 - Not Found
+	_, err = client.DeleteWorkflow("1")
+	if err == nil {
+		t.Fatalf("DeleteWorkflow should have returned an HTTP 404 error")
+	}
+
+	// HTTP 200 - Workflow deleted
+	workflow, err := client.DeleteWorkflow("3LODqkaWPmYOi0FA")
+	if err != nil {
+		t.Fatalf("DeleteWorkflow returned an error: %v", err)
 	}
 
 	if workflow.ID != "3LODqkaWPmYOi0FA" {


### PR DESCRIPTION
* New operation `DeleteWorkflow` added to the N8N Go client.
* Workflows can now be deleted based on the API method [Delete a Workflow](https://docs.n8n.io/api/api-reference/#tag/Workflow/paths/~1workflows~1%7Bid%7D/delete).
* Unit tests included in `workflows_test.go` with extra verification of workflow ID defined in the URL base path.
  * This additional check allows to perform tests for both HTTP 200 and 404.