### PR TITLE
Initial CI Pipeline Setup and golangci-lint Config Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Format
+        run: gofmt -s -w -e .
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          only-new-issues: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: go install -v ./...
+
+      - name: Build
+        run: go build -v ./...
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run Tests
+        run: go test -v -cover -timeout=120s -parallel=10 ./...
+
+  testacc:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Run Acceptance Tests
+        run: TF_ACC=1 go test -v -cover -timeout 120m ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
   max-same-issues: 0
 
 linters:


### PR DESCRIPTION
This PR introduces the initial Continuous Integration (CI) pipeline using GitHub Actions for automated testing, formatting, linting, and building of the project.

### 🔧 What's included

- New GitHub Actions workflow (`.github/workflows/ci.yml`):
  - Format step using `gofmt`
  - Lint step via `golangci-lint` (latest version, using GitHub Action)
  - Dependency installation
  - Build step with `go build`
  - Test job running unit tests with coverage
  - TestAcc job for acceptance testing with `TF_ACC=1`

---

### 🛠 Configuration Fix

- Removed invalid `max-per-linter` field from `.golangci.yml`
    - This field has been deprecated and is no longer supported in recent versions (v1.64+).

---

### 📎 References

    [golangci-lint changelog](https://github.com/golangci/golangci-lint/releases)
    [GitHub Actions documentation](https://docs.github.com/en/actions)

---

### 🔒 Signed-off-by

    Arthur Diniz `<arthurbdiniz@gmail.com>`