### PR TITLE
Add ActivateWorkflow Method with Unit Test

### DIFF
--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -113,3 +113,23 @@ func (c *Client) DeactivateWorkflow(workflowID string) (*Workflow, error) {
 
 	return &workflow, nil
 }
+
+// ActivateWorkflow - Activates a workflow by its ID.
+func (c *Client) ActivateWorkflow(workflowID string) (*Workflow, error) {
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/workflows/%s/activate", c.HostURL, workflowID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	workflow := Workflow{}
+	if err := json.Unmarshal(body, &workflow); err != nil {
+		return nil, err
+	}
+
+	return &workflow, nil
+}

--- a/internal/pkg/n8n-client-go/workflows_test.go
+++ b/internal/pkg/n8n-client-go/workflows_test.go
@@ -168,3 +168,37 @@ func TestDeactivateWorkflow(t *testing.T) {
 		t.Errorf("unexpected workflow data: %+v", workflow)
 	}
 }
+
+func TestActivateWorkflow(t *testing.T) {
+	mockResponse := `{"id": "2tUt1wbLX592XDdX", "name": "Activated Workflow", "active": true}`
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/workflows/2tUt1wbLX592XDdX/activate" {
+			t.Errorf("unexpected URL path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(mockResponse)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	})
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	token := "test-token"
+	client, err := NewClient(&ts.URL, &token)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	workflow, err := client.ActivateWorkflow("2tUt1wbLX592XDdX")
+	if err != nil {
+		t.Fatalf("ActivateWorkflow returned an error: %v", err)
+	}
+
+	if workflow.ID != "2tUt1wbLX592XDdX" || workflow.Name != "Activated Workflow" || !workflow.Active {
+		t.Errorf("unexpected workflow data: %+v", workflow)
+	}
+}


### PR DESCRIPTION
This PR introduces a new method `ActivateWorkflow` to the `n8n-client-go` package, allowing workflows to be activated via the `/api/v1/workflows/{id}/activate` API endpoint.

### ✨ What's Included

- ✅ New `ActivateWorkflow` method in the client.
- ✅ Unit test `TestActivateWorkflow` using `httptest.Server` to validate behavior.
- ✅ Test coverage for HTTP method, request path, and response parsing.

### 🔍 Why

This addition expands the client functionality to support workflow lifecycle operations, improving its usefulness for automation and infrastructure as code scenarios.

Closes #4