### PR TITLE
Add DeactivateWorkflow Method with Unit Test

### DIFF
--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -93,3 +93,23 @@ func (c *Client) DeleteWorkflow(workflowID string) (*Workflow, error) {
 
 	return &workflow, nil
 }
+
+// DeactivateWorkflow - Deactivates a workflow by its ID.
+func (c *Client) DeactivateWorkflow(workflowID string) (*Workflow, error) {
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/workflows/%s/deactivate", c.HostURL, workflowID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(req, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	workflow := Workflow{}
+	if err := json.Unmarshal(body, &workflow); err != nil {
+		return nil, err
+	}
+
+	return &workflow, nil
+}

--- a/internal/pkg/n8n-client-go/workflows_test.go
+++ b/internal/pkg/n8n-client-go/workflows_test.go
@@ -134,3 +134,37 @@ func TestDeleteWorkflow(t *testing.T) {
 		t.Errorf("unexpected workflow data: %+v", workflow)
 	}
 }
+
+func TestDeactivateWorkflow(t *testing.T) {
+	mockResponse := `{"id": "2tUt1wbLX592XDdX", "name": "Deactivated Workflow", "active": false}`
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/workflows/2tUt1wbLX592XDdX/deactivate" {
+			t.Errorf("unexpected URL path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(mockResponse)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	})
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	token := "test-token"
+	client, err := NewClient(&ts.URL, &token)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	workflow, err := client.DeactivateWorkflow("2tUt1wbLX592XDdX")
+	if err != nil {
+		t.Fatalf("DeactivateWorkflow returned an error: %v", err)
+	}
+
+	if workflow.ID != "2tUt1wbLX592XDdX" || workflow.Name != "Deactivated Workflow" || workflow.Active {
+		t.Errorf("unexpected workflow data: %+v", workflow)
+	}
+}


### PR DESCRIPTION
This PR introduces a new method `DeactivateWorkflow` to the `n8n-client-go` package, allowing workflows to be deactivated via the `/api/v1/workflows/{id}/deactivate` API endpoint.

### ✨ What's Included

- ✅ New `DeactivateWorkflow` method in the client.
- ✅ Unit test `TestDeactivateWorkflow` using `httptest.Server` to validate behavior.
- ✅ Test coverage for HTTP method, request path, and response parsing.

### 🔍 Why

This addition expands the client functionality to support workflow lifecycle operations, improving its usefulness for automation and infrastructure as code scenarios.

Closes #5