### PR TITLE
Remove authToken from doRequest method

### DIFF
--- a/internal/pkg/n8n-client-go/client.go
+++ b/internal/pkg/n8n-client-go/client.go
@@ -34,12 +34,8 @@ func NewClient(host, token *string) (*Client, error) {
 	return &c, nil
 }
 
-func (c *Client) doRequest(req *http.Request, authToken *string) ([]byte, error) {
+func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	token := c.Token
-
-	if authToken != nil {
-		token = *authToken
-	}
 
 	req.Header.Set("X-N8N-API-KEY", token)
 

--- a/internal/pkg/n8n-client-go/client_test.go
+++ b/internal/pkg/n8n-client-go/client_test.go
@@ -53,44 +53,7 @@ func TestDoRequest(t *testing.T) {
 		t.Fatalf("failed to create request: %v", err)
 	}
 
-	respBody, err := client.doRequest(req, nil)
-	if err != nil {
-		t.Fatalf("doRequest returned an error: %v", err)
-	}
-
-	if string(respBody) != mockResponse {
-		t.Errorf("expected response body %s, got %s", mockResponse, string(respBody))
-	}
-}
-
-func TestDoRequestWithAuthToken(t *testing.T) {
-	mockResponse := `{"message": "authorized"}`
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-N8N-API-KEY") != "override-token" {
-			t.Errorf("expected token override-token, got %s", r.Header.Get("X-N8N-API-KEY"))
-		}
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(mockResponse)); err != nil {
-			t.Errorf("failed to write response: %v", err)
-		}
-	})
-
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	token := "test-token"
-	client, err := NewClient(&ts.URL, &token)
-	if err != nil {
-		t.Fatalf("failed to create client: %v", err)
-	}
-
-	overrideToken := "override-token"
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-	if err != nil {
-		t.Fatalf("failed to create request: %v", err)
-	}
-
-	respBody, err := client.doRequest(req, &overrideToken)
+	respBody, err := client.doRequest(req)
 	if err != nil {
 		t.Fatalf("doRequest returned an error: %v", err)
 	}

--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -31,7 +31,7 @@ func (c *Client) GetWorkflows() (*WorkflowsResponse, error) {
 			return nil, err
 		}
 
-		body, err := c.doRequest(req, nil)
+		body, err := c.doRequest(req)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +59,7 @@ func (c *Client) GetWorkflow(workflowID string) (*Workflow, error) {
 		return nil, err
 	}
 
-	body, err := c.doRequest(req, nil)
+	body, err := c.doRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *Client) DeleteWorkflow(workflowID string) (*Workflow, error) {
 		return nil, err
 	}
 
-	body, err := c.doRequest(req, nil)
+	body, err := c.doRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *Client) DeactivateWorkflow(workflowID string) (*Workflow, error) {
 		return nil, err
 	}
 
-	body, err := c.doRequest(req, nil)
+	body, err := c.doRequest(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request removes the `authToken` parameter from the `doRequest` method in the n8n-client-go package. The method now uses the Token field from the Client structure directly, simplifying the code and eliminating the need to pass an override token for each request.

### Changes include:

1. `client.go`: Modified the `doRequest` method to no longer accept the `authToken` parameter.
2. `client_test.go`: Updated tests to reflect the change, removing test cases that used the `authToken` parameter.
3. `workflows.go`: Updated workflow-related methods to no longer pass an `authToken` when calling `doRequest`.

This change enhances code readability and consistency by relying on the Client's internal Token for authentication across all requests.