### PR TITLE
Make host and token mandatory for newClient method

### DIFF
--- a/internal/pkg/n8n-client-go/client.go
+++ b/internal/pkg/n8n-client-go/client.go
@@ -10,25 +10,26 @@ import (
 	"time"
 )
 
-const HostURL string = "http://localhost:5678"
-
 type Client struct {
 	HostURL    string
 	HTTPClient *http.Client
 	Token      string
 }
 
-func NewClient(host, token *string) (*Client, error) {
+func NewClient(host *string, token *string) (*Client, error) {
+	if token == nil {
+		return nil, fmt.Errorf("token is required")
+	}
+
+	if host == nil {
+		return nil, fmt.Errorf("host is required")
+	}
+
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
-		// Default n8n URL
-		HostURL: HostURL,
 	}
 
-	if host != nil {
-		c.HostURL = *host
-	}
-
+	c.HostURL = *host
 	c.Token = *token
 
 	return &c, nil

--- a/internal/pkg/n8n-client-go/client_test.go
+++ b/internal/pkg/n8n-client-go/client_test.go
@@ -27,6 +27,38 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientWithoutToken(t *testing.T) {
+	host := "http://example.com"
+
+	client, err := NewClient(&host, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "token is required" {
+		t.Errorf("expected error message 'token is required', got %v", err)
+	}
+
+	if client != nil {
+		t.Fatal("expected nil client, got a non-nil client")
+	}
+}
+
+func TestNewClientWithoutHost(t *testing.T) {
+	token := "test-token"
+
+	client, err := NewClient(nil, &token)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "host is required" {
+		t.Errorf("expected error message 'host is required', got %v", err)
+	}
+
+	if client != nil {
+		t.Fatal("expected nil client, got a non-nil client")
+	}
+}
+
 func TestDoRequest(t *testing.T) {
 	mockResponse := `{"message": "success"}`
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Summary:
This pull request updates the `NewClient` function in the `n8n-client-go` package to enforce that both the `host` and `token` parameters are mandatory. If either parameter is not provided (i.e., `nil`), the function will now return an error indicating which parameter is missing. 

### Changes:
- **client.go**:
  - Modified the `NewClient` function to check if `token` and `host` are `nil` and return appropriate error messages (`"token is required"` and `"host is required"`) if they are missing.
  
- **client_test.go**:
  - Added two new test cases to validate the behavior when the `token` or `host` is not provided:
    - `TestNewClientWithoutToken`: Ensures an error is returned when `token` is `nil`.
    - `TestNewClientWithoutHost`: Ensures an error is returned when `host` is `nil`.

### Benefits:
- Ensures that the `NewClient` method always receives the necessary parameters to create a valid client, reducing the possibility of errors due to missing configuration.
- Improves error handling by providing clear and specific error messages when required parameters are not passed.
- Adds unit tests to verify the changes and ensure correct behavior when either the `token` or `host` is omitted.
