### PR TITLE
Add Test Coverage Reporting and Codecov Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,18 @@ jobs:
           go-version: stable
 
       - name: Run Tests
-        run: go test -v -cover -timeout=120s -parallel=10 ./...
+        run: go test -v -cover -coverprofile=coverage.out -timeout=120s -parallel=10 ./...
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   testacc:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ website/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+
+# Coverage
+coverage.html
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ fmt:
 	gofmt -s -w -e .
 
 test:
-	go test -v -cover -timeout=120s -parallel=10 ./...
+	go test -v -cover -coverprofile=coverage.out -timeout=120s -parallel=10 ./...
+
+coverage-html:
+	go tool cover -html=coverage.out -o coverage.html
 
 testacc:
 	TF_ACC=1 go test -v -cover -timeout 120m ./...


### PR DESCRIPTION
This PR introduces test coverage reporting enhancements to improve the visibility and quality of our test suite.

### ✅ Changes Summary

- **CI Workflow (`.github/workflows/ci.yml`)**
  - Added `-coverprofile=coverage.out` flag to the `go test` command to generate test coverage data.
  - Uploaded `coverage.out` as a GitHub Actions artifact.
  - Integrated [Codecov](https://about.codecov.io/) to upload coverage data and track code coverage across builds.

- **Makefile**
  - Updated the `test` target to include coverage profile generation.
  - Added a new `coverage-html` target to generate an HTML coverage report (`coverage.html`).

- **.gitignore**
  - Added `coverage.out` and `coverage.html` to the ignore list to prevent accidental commits of coverage files.

### 📊 Benefits

- Easy access to test coverage metrics for each CI run.
- Improved visibility into untested code paths.
- Codecov integration enables coverage tracking, insights, and PR-level reporting.