### PR TITLE
Add support for updating workflows via UpdateWorkflow method

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -22,6 +22,7 @@ The package also includes an HTTP client to facilitate communication with the n8
   - [func \(c \*Client\) DeleteWorkflow\(workflowID string\) \(\*Workflow, error\)](<#Client.DeleteWorkflow>)
   - [func \(c \*Client\) GetWorkflow\(workflowID string\) \(\*Workflow, error\)](<#Client.GetWorkflow>)
   - [func \(c \*Client\) GetWorkflows\(\) \(\*WorkflowsResponse, error\)](<#Client.GetWorkflows>)
+  - [func \(c \*Client\) UpdateWorkflow\(id string, updateWorkflowRequest \*UpdateWorkflowRequest\) \(\*Workflow, error\)](<#Client.UpdateWorkflow>)
 - [type Connection](<#Connection>)
 - [type ConnectionDetail](<#ConnectionDetail>)
 - [type CreateWorkflowRequest](<#CreateWorkflowRequest>)
@@ -29,6 +30,7 @@ The package also includes an HTTP client to facilitate communication with the n8
 - [type Node](<#Node>)
 - [type Settings](<#Settings>)
 - [type Tag](<#Tag>)
+- [type UpdateWorkflowRequest](<#UpdateWorkflowRequest>)
 - [type Workflow](<#Workflow>)
 - [type WorkflowsResponse](<#WorkflowsResponse>)
 
@@ -147,6 +149,22 @@ GetWorkflows retrieves all workflows from your n8n instance. This method support
 
 Returns a pointer to a WorkflowsResponse containing all workflows, or an error if the request or response decoding fails.
 
+<a name="Client.UpdateWorkflow"></a>
+### func \(\*Client\) UpdateWorkflow
+
+```go
+func (c *Client) UpdateWorkflow(id string, updateWorkflowRequest *UpdateWorkflowRequest) (*Workflow, error)
+```
+
+UpdateWorkflow sends a request to update an existing workflow in n8n. It accepts the workflow ID and an UpdateWorkflowRequest object, then returns the updated Workflow with its assigned ID and metadata.
+
+Parameters:
+
+- id: the ID of the workflow to be updated.
+- updateWorkflowRequest: the updated workflow data.
+
+Returns the updated Workflow object or an error if the request or decoding fails.
+
 <a name="Connection"></a>
 ## type Connection
 
@@ -261,6 +279,20 @@ type Tag struct {
 
     // Name is the name of the tag.
     Name string `json:"name"`
+}
+```
+
+<a name="UpdateWorkflowRequest"></a>
+## type UpdateWorkflowRequest
+
+UpdateWorkflowRequest defines the allowed fields when updating a workflow.
+
+```go
+type UpdateWorkflowRequest struct {
+    Name        string                `json:"name"`
+    Nodes       []Node                `json:"nodes"`
+    Connections map[string]Connection `json:"connections"`
+    Settings    Settings              `json:"settings"`
 }
 ```
 

--- a/internal/pkg/n8n-client-go/models.go
+++ b/internal/pkg/n8n-client-go/models.go
@@ -135,3 +135,12 @@ type CreateWorkflowRequest struct {
 	Settings    Settings              `json:"settings"`
 	// StaticData   interface{}           `json:"staticData"` // TODO understand how this parameter is used and make it exportable to the state
 }
+
+// UpdateWorkflowRequest defines the allowed fields when updating a workflow.
+type UpdateWorkflowRequest struct {
+	Name        string                `json:"name"`
+	Nodes       []Node                `json:"nodes"`
+	Connections map[string]Connection `json:"connections"`
+	Settings    Settings              `json:"settings"`
+	// StaticData   interface{}           `json:"staticData"` // TODO understand how this parameter is used and make it exportable to the state
+}

--- a/internal/pkg/n8n-client-go/workflows.go
+++ b/internal/pkg/n8n-client-go/workflows.go
@@ -173,6 +173,45 @@ func (c *Client) CreateWorkflow(createWorkflowRequest *CreateWorkflowRequest) (*
 
 	// Create the HTTP POST request
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/v1/workflows", c.HostURL), bytes.NewReader(payload))
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Perform the request
+	body, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	// Decode the response into a Workflow
+	workflow := &Workflow{}
+	if err := json.Unmarshal(body, workflow); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return workflow, nil
+}
+
+// UpdateWorkflow sends a request to update an existing workflow in n8n.
+// It accepts the workflow ID and an UpdateWorkflowRequest object, then returns the updated Workflow with its assigned ID and metadata.
+//
+// Parameters:
+//   - id: the ID of the workflow to be updated.
+//   - updateWorkflowRequest: the updated workflow data.
+//
+// Returns the updated Workflow object or an error if the request or decoding fails.
+func (c *Client) UpdateWorkflow(id string, updateWorkflowRequest *UpdateWorkflowRequest) (*Workflow, error) {
+	// Marshal the updated workflow into JSON
+	payload, err := json.Marshal(updateWorkflowRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated workflow: %w", err)
+	}
+
+	// Create the HTTP PUT request
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/api/v1/workflows/%s", c.HostURL, id), bytes.NewReader(payload))
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
### Description:

This pull request introduces full support for updating workflows through the n8n Go client, including the following changes:

#### New Features
- **UpdateWorkflowRequest model**: Defines the schema for sending updates to workflows, mirroring the structure of `CreateWorkflowRequest`.
- **UpdateWorkflow client method**: Implements the `PUT /api/v1/workflows/{id}` request to update existing workflows.

#### Tests
- **Unit test** for the `UpdateWorkflow` method to validate request formatting and response parsing.
- **Integration test** using a running n8n container to confirm end-to-end update functionality.

#### Documentation
- Basic client documentation updated to include `UpdateWorkflow`.